### PR TITLE
fix test suite naming with fire parsing

### DIFF
--- a/hil/main.py
+++ b/hil/main.py
@@ -110,7 +110,7 @@ def main(
         "secrets": SecretsTestSuite(
             CheckRunner(), artifacts_destination_path, test_configuration
         ),
-        "secrets-full": SecretsFullTestSuite(
+        "secrets_full": SecretsFullTestSuite(
             CheckRunner(), artifacts_destination_path, test_configuration
         ),
     }


### PR DESCRIPTION
Fixes problem with fire not parsing tuples of strings with `-` in them as tuples, but instead just as strings.